### PR TITLE
feat: coerce the build/release PR trigger to use branch name

### DIFF
--- a/generators/gh-maven-build/templates/build-release.yaml
+++ b/generators/gh-maven-build/templates/build-release.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
             fetch-depth: 0
             fetch-tags: true
-            ref: ${{ github.ref }}
+            ref: ${{ github.head_ref || github.ref }}
       - name: Set up Java
         uses: actions/setup-java@v4
         with:

--- a/generators/gh-nodejs-build/templates/build-release.yaml
+++ b/generators/gh-nodejs-build/templates/build-release.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
             fetch-depth: 0
             fetch-tags: true
-            ref: ${{ github.ref }}
+            ref: ${{ github.head_ref || github.ref }}
       - name: Setup ORAS
         uses: oras-project/setup-oras@v1
       - name: Set up Node


### PR DESCRIPTION
When the build/release workflow is triggered by a pull request, the `github.ref` value will refer to a pseudo-merge commit as if the branch has been merged eg. `refs/remotes/pull/21/merge`

This means that when the build is triggered automatically from PR activity, the merge commit is passed to Broker, and this is a different commit than the tip of the branch.

If the goal is to run a development version deploy job, this means that the build/release workflow needs to be triggered again manually after the automated trigger is complete to update broker with the hash from the tip of the branch.

Edit: See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context regarding `github.head_ref` and `github.ref`

------

This PR fixes the build/release action by coercing the `ref` passed to the checkout action to use `github.head_ref`.
Developers can wait for the automated workflow to finish and immediately use the deploy action without making the broker grumpy.

`github.head_ref` is equal to the branch name (ex. `feat/branch`) for `pull_request` triggered workflows. Otherwise `github.head_ref` is `null`, (ie. because the workflow is triggered manually) and `github.ref` will be `refs/heads/feat/branch`.