### PR TITLE
fix: gate Maven README section behind hasMavenBuild flag

### DIFF
--- a/generators/util/pd-template/env-build.sh
+++ b/generators/util/pd-template/env-build.sh
@@ -25,9 +25,12 @@ export PUBLISH_DIR="<%= (typeof publishArtifactSuffix !== 'undefined' && publish
 # Maven build configuration
 export POM_ROOT="<%= pomRoot %>"
 export MAVEN_ARGS="--file $POM_ROOT"
-<% } -%>
-
 export VERSION="${VERSION:-0.0.0-SNAPSHOT}"
+<% } else { -%>
+# Non-Maven build configuration (e.g. Node)
+DEFAULT_VERSION="$(jq -r '.version // empty' "$(dirname "${BASH_SOURCE[0]}")/package.json" 2>/dev/null)"
+export VERSION="${VERSION:-${DEFAULT_VERSION:-0.0.0}}"
+<% } -%>
 <% if (toolsLocalBuildSecrets) { %>
 # Only fetch vault secrets if --skip-vault is not set
 if [[ "$SKIP_VAULT" == false ]]; then

--- a/generators/util/pd-template/env-build.sh
+++ b/generators/util/pd-template/env-build.sh
@@ -19,12 +19,12 @@ fi
 export PROJECT_NAME="<%= projectName %>"
 export SERVICE_NAME="<%= serviceName %>"
 export PACKAGE_REPO="<%= artifactRepositoryPath %>"
-export PUBLISH_DIR="<%= (typeof publishArtifactSuffix !== 'undefined' && publishArtifactSuffix ? publishArtifactSuffix.split(' ')[0] : 'dist') %>"
 
 <% if (pomRoot) { -%>
 # Maven build configuration
 export POM_ROOT="<%= pomRoot %>"
 export MAVEN_ARGS="--file $POM_ROOT"
+export PUBLISH_DIR="<%= (typeof publishArtifactSuffix !== 'undefined' && publishArtifactSuffix ? publishArtifactSuffix.split(' ')[0] : 'dist') %>"
 export VERSION="${VERSION:-0.0.0-SNAPSHOT}"
 <% } else { -%>
 # Non-Maven build configuration (e.g. Node)

--- a/generators/util/pd-template/gh-docs/README-buildenv.md.tpl
+++ b/generators/util/pd-template/gh-docs/README-buildenv.md.tpl
@@ -33,6 +33,7 @@ source env.sh local
 # Skip Vault authentication
 source env.sh build --skip-vault
 ```
+<% if (hasMavenBuild) { -%>
 
 #### Setting the Artifact Version
 
@@ -66,6 +67,7 @@ VERSION=1.2.0-SNAPSHOT ./mvnw clean package
 ```
 
 To bump the base development version, update only the `VERSION` file — `.env-build.sh` and the pipeline both derive from it automatically.
+<% } -%>
 <% } else if (isMonorepo) { -%>
 <!-- Monorepo Repository (Location with Components) -->
 


### PR DESCRIPTION
The README build-env template was unconditionally including Maven-specific content (pom.xml, mvn commands, etc.) for all non-monorepo builds, including Node.js projects. This fix gates the entire 'Setting the Artifact Version' section to only render when hasMavenBuild is true, preventing Java/Maven content from appearing in language-specific repos like nr-nodejs-sample.

The hasMavenBuild flag is computed in copyworkflows.js but was not being used by the template. Now it properly restricts Maven documentation to projects that actually contain Maven build generators.