### PR TITLE
fix: gate maven readme section

### DIFF
--- a/generators/gh-nodejs-build/templates/build-release.yaml
+++ b/generators/gh-nodejs-build/templates/build-release.yaml
@@ -217,7 +217,7 @@ jobs:
         working-directory: ./<%= relativePath %>
       - name: Send build info
         run: |
-          curl -s POST ${{ env.BROKER_URL }}/v1/intention/action/patch \
+          curl -s -X POST ${{ env.BROKER_URL }}/v1/intention/action/patch \
               -H 'Content-Type: application/json' \
               -H 'X-Broker-Token: '"${BUILD_TOKEN}"'' \
               -d '{"package":{"checksum": "sha256:'${ARTIFACT_SHA256}'", "size": '${ARTIFACT_SIZE}'}}'

--- a/generators/gh-oci-deploy-onprem/templates/deploy.yaml
+++ b/generators/gh-oci-deploy-onprem/templates/deploy.yaml
@@ -98,7 +98,7 @@ jobs:
             '{"actions.action":"package-build","actions.service.project":$serviceProject,"actions.service.name":$serviceName,"actions.package.version":$artifactTag} | @uri')
 
           RESPONSE=$(curl -s -X 'POST' \
-            "${BROKER_URL}/v1/intention/search?where=${WHERE_QUERY}&offset=0&limit=1" \
+            "${BROKER_URL}/v1/intention/search?where=${WHERE_QUERY}&offset=0&limit=20" \
             -H 'accept: application/json' \
             -H 'Authorization: Bearer '"${BROKER_JWT}"'' \
             -d '')
@@ -181,14 +181,49 @@ jobs:
             echo
             exit 1
           fi
-          echo "project_version=$(echo ${RESPONSE} | jq -r '.data[].actions[].package.version')" >> $GITHUB_OUTPUT
-          echo "build_guid=$(echo ${RESPONSE} | jq -r '.data[].id')" >> $GITHUB_OUTPUT
-          echo "build_number=$(echo ${RESPONSE} | jq -r '.data[].actions[].package.buildNumber')" >> $GITHUB_OUTPUT
+          SELECTED_RECORD=$(echo "$RESPONSE" | jq -c --arg packageTag "$PACKAGE_TAG" '
+            .data
+            | map(select((.actions[0].package.version // "") | endswith("-" + $packageTag)))
+            | .[0]
+          ')
+
+          if [[ -z "${SELECTED_RECORD}" || "${SELECTED_RECORD}" == "null" ]]; then
+            echo
+            echo "============================================================"
+            echo "Error: No Broker record matched expected package tag ${PACKAGE_TAG}."
+            echo "------------------------------------------------------------"
+            echo "Build SHA: ${BUILD_SHA}"
+            echo "Why it matters: Deployment must use metadata for the same artifact tag sent to Jenkins."
+            echo "--- Broker candidate summary ---"
+            echo "$RESPONSE" | jq -r '.data[] | { id, packageVersion: (.actions[0].package.version // "") }'
+            echo "============================================================"
+            echo
+            exit 1
+          fi
+
+          echo "project_version=$(echo "$SELECTED_RECORD" | jq -r '.actions[0].package.version')" >> $GITHUB_OUTPUT
+          echo "build_guid=$(echo "$SELECTED_RECORD" | jq -r '.id')" >> $GITHUB_OUTPUT
+          echo "build_number=$(echo "$SELECTED_RECORD" | jq -r '.actions[0].package.buildNumber')" >> $GITHUB_OUTPUT
 <% if (artifactSrc && artifactSrc === 'repo') { -%>
-          echo "build_version=$(echo ${RESPONSE} | jq -r '.data[].actions[].package.buildVersion')" >> $GITHUB_OUTPUT
+          echo "build_version=$(echo "$SELECTED_RECORD" | jq -r '.actions[0].package.buildVersion')" >> $GITHUB_OUTPUT
 <% } -%>
-          echo "artifact_name=$(echo ${RESPONSE} | jq -r '.data[].actions[].artifacts[].name')" >> $GITHUB_OUTPUT
-          artifact_checksum=$(echo ${RESPONSE} | jq -r '.data[].actions[].artifacts[].checksum')
+          echo "artifact_name=$(echo "$SELECTED_RECORD" | jq -r '.actions[0].artifacts[0].name')" >> $GITHUB_OUTPUT
+          artifact_checksum=$(echo "$SELECTED_RECORD" | jq -r '.actions[0].artifacts[0].checksum // empty')
+
+          if [[ -z "${artifact_checksum}" ]]; then
+            echo
+            echo "============================================================"
+            echo "Error: Broker returned an empty artifact checksum."
+            echo "------------------------------------------------------------"
+            echo "Build SHA: ${BUILD_SHA}"
+            echo "Why it matters: Jenkins checksum validation will always fail with an empty expected value."
+            echo "Check if the build workflow successfully patched package.checksum in Broker."
+            echo "--- Broker API response below ---"
+            echo "$RESPONSE"
+            echo "============================================================"
+            echo
+            exit 1
+          fi
           echo "artifact_sha256=${artifact_checksum#sha256:}" >> $GITHUB_OUTPUT
         env:
           BROKER_URL: https://broker.io.nrs.gov.bc.ca
@@ -196,6 +231,7 @@ jobs:
           SERVICE_PROJECT: ${{ env.SERVICE_PROJECT }}
           SERVICE_NAME: ${{ env.SERVICE_NAME }}
           BUILD_SHA: ${{ steps.lookup-pr-merge-ref.outputs.build_sha }}
+          PACKAGE_TAG: ${{ steps.lookup-pr-merge-ref.outputs.package_tag }}
       - name: Checkout repository
         uses: actions/checkout@v6
         with:

--- a/generators/util/pd-template/env-build.sh
+++ b/generators/util/pd-template/env-build.sh
@@ -25,9 +25,12 @@ export PUBLISH_DIR="<%= (typeof publishArtifactSuffix !== 'undefined' && publish
 # Maven build configuration
 export POM_ROOT="<%= pomRoot %>"
 export MAVEN_ARGS="--file $POM_ROOT"
-<% } -%>
-
 export VERSION="${VERSION:-0.0.0-SNAPSHOT}"
+<% } else { -%>
+# Non-Maven build configuration (e.g. Node)
+DEFAULT_VERSION="$(jq -r '.version // empty' "$(dirname "${BASH_SOURCE[0]}")/package.json" 2>/dev/null)"
+export VERSION="${VERSION:-${DEFAULT_VERSION:-0.0.0}}"
+<% } -%>
 <% if (toolsLocalBuildSecrets) { %>
 # Only fetch vault secrets if --skip-vault is not set
 if [[ "$SKIP_VAULT" == false ]]; then

--- a/generators/util/pd-template/env-build.sh
+++ b/generators/util/pd-template/env-build.sh
@@ -19,12 +19,12 @@ fi
 export PROJECT_NAME="<%= projectName %>"
 export SERVICE_NAME="<%= serviceName %>"
 export PACKAGE_REPO="<%= artifactRepositoryPath %>"
-export PUBLISH_DIR="<%= (typeof publishArtifactSuffix !== 'undefined' && publishArtifactSuffix ? publishArtifactSuffix.split(' ')[0] : 'dist') %>"
 
 <% if (pomRoot) { -%>
 # Maven build configuration
 export POM_ROOT="<%= pomRoot %>"
 export MAVEN_ARGS="--file $POM_ROOT"
+export PUBLISH_DIR="<%= (typeof publishArtifactSuffix !== 'undefined' && publishArtifactSuffix ? publishArtifactSuffix.split(' ')[0] : 'dist') %>"
 export VERSION="${VERSION:-0.0.0-SNAPSHOT}"
 <% } else { -%>
 # Non-Maven build configuration (e.g. Node)

--- a/generators/util/pd-template/gh-docs/README-buildenv.md.tpl
+++ b/generators/util/pd-template/gh-docs/README-buildenv.md.tpl
@@ -33,6 +33,7 @@ source env.sh local
 # Skip Vault authentication
 source env.sh build --skip-vault
 ```
+<% if (hasMavenBuild) { -%>
 
 #### Setting the Artifact Version
 
@@ -66,6 +67,7 @@ VERSION=1.2.0-SNAPSHOT ./mvnw clean package
 ```
 
 To bump the base development version, update only the `VERSION` file — `.env-build.sh` and the pipeline both derive from it automatically.
+<% } -%>
 <% } else if (isMonorepo) { -%>
 <!-- Monorepo Repository (Location with Components) -->
 


### PR DESCRIPTION
## Summary
This PR fixes workflow generation to prevent deploy checksum mismatches and make Broker patching explicit.

## Changes
1. generators/gh-oci-deploy-onprem/templates/deploy.yaml
- Broker lookup now selects the record matching the expected `PACKAGE_TAG` (instead of relying on first result for a shared build SHA).
- Added fail-fast when no matching record is found.
- Added fail-fast for empty checksum on selected record.

2. generators/gh-nodejs-build/templates/build-release.yaml
- Changed Broker patch call from `curl -s POST ...` to `curl -s -X POST ...`.

## Why
Multiple Broker records can exist for the same `buildVersion` (SHA) with different package versions/checksums. First-result selection can pair the wrong checksum with the deployed artifact tag.

## Validation
Validated in `nr-nodejs-sample`: repeated build/deploy runs resolved the correct metadata and Jenkins checksum verification passed. Reapplying latest composer generators showed no workflow drift.