### PR TITLE
docs: require gh pr body-file for multiline summaries

### DIFF
--- a/.github/skills/polaris-pipeline-composer/SKILL.md
+++ b/.github/skills/polaris-pipeline-composer/SKILL.md
@@ -50,7 +50,17 @@ Use this skill for staff-supervised updates that apply the latest Polaris Pipeli
    - `git add <expected-generated-files>`
    - `git commit -m "chore: refresh Polaris Pipeline files"`
    - `git push -u origin feat/polaris-composer-<service>`
-   - `gh pr create --fill`
+   - For multiline PR content, write the PR body to a temporary Markdown file and use `--body-file`.
+   - Example:
+     - `cat > /tmp/pr-body.md <<'EOF'`
+     - `## Summary`
+     - `- Describe generated changes.`
+     - ``
+     - `## Validation`
+     - `- List checks performed.`
+     - `EOF`
+     - `gh pr create --base main --head feat/polaris-composer-<service> --title "chore: refresh Polaris Pipeline files" --body-file /tmp/pr-body.md`
+   - Do not pass escaped newline sequences like `\n` to `--body`; GitHub will render them as literal text.
 10. If there are no changes, exit cleanly.
 
 ## Path B: Multi-Repo Staff Session

--- a/generators/gh-polaris-composer-agent/templates/.github/skills/polaris-pipeline-composer/SKILL.md
+++ b/generators/gh-polaris-composer-agent/templates/.github/skills/polaris-pipeline-composer/SKILL.md
@@ -60,7 +60,17 @@ Use this skill for staff-supervised updates that apply the latest Polaris Pipeli
     - `git add <expected-generated-files>`
     - `git commit -m "chore: refresh Polaris Pipeline files"`
     - `git push -u origin feat/polaris-composer-<service>`
-    - `gh pr create --fill`
+      - For multiline PR content, write the PR body to a temporary Markdown file and use `--body-file`.
+      - Example:
+         - `cat > /tmp/pr-body.md <<'EOF'`
+         - `## Summary`
+         - `- Describe generated changes.`
+         - ``
+         - `## Validation`
+         - `- List checks performed.`
+         - `EOF`
+         - `gh pr create --base main --head feat/polaris-composer-<service> --title "chore: refresh Polaris Pipeline files" --body-file /tmp/pr-body.md`
+      - Do not pass escaped newline sequences like `\n` to `--body`; GitHub will render them as literal text.
 11. If there are no changes, exit cleanly.
 
 ## Path B: Multi-Repo Staff Session


### PR DESCRIPTION
## Summary
- Update the Polaris composer skill guidance to prevent malformed PR Markdown.
- Require `gh pr create --body-file` for multiline PR bodies.
- Add explicit guidance to avoid escaped newline sequences in `--body`.

## Validation
- Verified both skill sources include the new `--body-file` guidance.
- Verified both skill sources include the escaped-newline warning.
