### PR TITLE
feat: improve artifact tag resolution in run-deploy template

### DIFF
--- a/generators/util/gh-workflow-template/run-deploy.yaml
+++ b/generators/util/gh-workflow-template/run-deploy.yaml
@@ -17,8 +17,8 @@ on:
         type: string
 <% if (artifactSrc && artifactSrc !== 'repo') { -%>
       artifact_tag:
-        description: 'Artifact/package tag (required for non-repository artifact sources)'
-        required: true
+        description: 'Artifact/package tag to deploy (optional). Leave blank to use the selected workflow tag ref, or auto-use the latest published <%= serviceName %> artifact tag when run from a branch.'
+        required: false
         type: string
 <% } -%>
 
@@ -62,15 +62,61 @@ jobs:
           echo "Latest deployment tag: $tag"
           echo "deploy_tag=$tag" >> $GITHUB_OUTPUT
 
+<% if (artifactSrc && artifactSrc !== 'repo') { -%>
+  find-artifact-tag:
+    name: Resolve artifact tag
+    runs-on: ubuntu-latest
+    outputs:
+      artifact_tag: ${{ steps.resolve.outputs.artifact_tag }}
+    steps:
+      - name: Resolve artifact tag
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_ARTIFACT_TAG: ${{ github.event.inputs.artifact_tag }}
+          SELECTED_REF_TYPE: ${{ github.ref_type }}
+          SELECTED_REF_NAME: ${{ github.ref_name }}
+          PACKAGE_NAME: ${{ github.event.repository.name }}/<%= serviceName %>
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          if [[ -n "${INPUT_ARTIFACT_TAG}" ]]; then
+            echo "Using provided artifact_tag: ${INPUT_ARTIFACT_TAG}"
+            echo "artifact_tag=${INPUT_ARTIFACT_TAG}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${SELECTED_REF_TYPE}" == "tag" ]]; then
+            echo "Using selected workflow tag as artifact_tag: ${SELECTED_REF_NAME}"
+            echo "artifact_tag=${SELECTED_REF_NAME}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          ENCODED_PACKAGE_NAME="${PACKAGE_NAME//\//%2F}"
+          ARTIFACT_TAG=$(gh api "orgs/${REPOSITORY_OWNER}/packages/container/${ENCODED_PACKAGE_NAME}/versions" --paginate | jq -r 'map(select((.metadata.container.tags // []) | length > 0)) | sort_by(.created_at) | reverse | .[0].metadata.container.tags[0] // empty')
+
+          if [[ -z "${ARTIFACT_TAG}" ]]; then
+            echo "::error::Could not auto-detect an artifact_tag from GHCR package ${PACKAGE_NAME}."
+            echo "Provide artifact_tag manually from a successful build version."
+            exit 1
+          fi
+
+          echo "Auto-detected artifact_tag: ${ARTIFACT_TAG}"
+          echo "artifact_tag=${ARTIFACT_TAG}" >> "$GITHUB_OUTPUT"
+<% } -%>
+
   deploy-development:
     name: Deploy to development
     uses: ./.github/workflows/<%= deployWorkflowFile %>
+<% if (artifactSrc && artifactSrc !== 'repo') { -%>
+    needs: [preflight, find-tag, find-artifact-tag]
+<% } else { -%>
     needs: [preflight, find-tag]
+<% } -%>
     with:
       environment: development
       deploy_tag: ${{ github.event.inputs.deploy_tag != '' && github.event.inputs.deploy_tag || needs.find-tag.outputs.deploy_tag }}
 <% if (artifactSrc && artifactSrc !== 'repo') { -%>
-      artifact_tag: ${{ github.event.inputs.artifact_tag }}
+      artifact_tag: ${{ needs.find-artifact-tag.outputs.artifact_tag }}
 <% } -%>
     secrets: inherit
     if: |
@@ -80,13 +126,17 @@ jobs:
 
   deploy-test:
     name: Deploy to test
+<% if (artifactSrc && artifactSrc !== 'repo') { -%>
+    needs: [deploy-development, find-tag, find-artifact-tag]
+<% } else { -%>
     needs: [deploy-development, find-tag]
+<% } -%>
     uses: ./.github/workflows/<%= deployWorkflowFile %>
     with:
       environment: test
       deploy_tag: ${{ github.event.inputs.deploy_tag != '' && github.event.inputs.deploy_tag || needs.find-tag.outputs.deploy_tag }}
 <% if (artifactSrc && artifactSrc !== 'repo') { -%>
-      artifact_tag: ${{ github.event.inputs.artifact_tag }}
+      artifact_tag: ${{ needs.find-artifact-tag.outputs.artifact_tag }}
 <% } -%>
     secrets: inherit
     if: |
@@ -95,13 +145,17 @@ jobs:
 
   deploy-production:
     name: Deploy to production
+<% if (artifactSrc && artifactSrc !== 'repo') { -%>
+    needs: [deploy-test, find-tag, find-artifact-tag]
+<% } else { -%>
     needs: [deploy-test, find-tag]
+<% } -%>
     uses: ./.github/workflows/<%= deployWorkflowFile %>
     with:
       environment: production
       deploy_tag: ${{ github.event.inputs.deploy_tag != '' && github.event.inputs.deploy_tag || needs.find-tag.outputs.deploy_tag }}
 <% if (artifactSrc && artifactSrc !== 'repo') { -%>
-      artifact_tag: ${{ github.event.inputs.artifact_tag }}
+      artifact_tag: ${{ needs.find-artifact-tag.outputs.artifact_tag }}
 <% } -%>
     secrets: inherit
     if: github.event.inputs.environment == 'production'


### PR DESCRIPTION
## Summary
- Update `run-deploy` template artifact tag resolution for non-repo artifact sources.
- Keep manual `artifact_tag` input as highest precedence.
- When `artifact_tag` is blank and workflow runs from a tag ref, use the selected ref name.
- When running from a branch and `artifact_tag` is blank, auto-detect latest published tagged package.
- Clarify workflow_dispatch input description to match this behavior.

## Validation
- Verified YAML/EJS template structure and resolver precedence in `run-deploy.yaml`.
- Confirmed only one template file changed in this branch.
