### PR TITLE
fix: pass artifactSrc catalog value to Jenkins deploy job

### DIFF
--- a/generators/gh-oci-deploy-onprem/templates/deploy.yaml
+++ b/generators/gh-oci-deploy-onprem/templates/deploy.yaml
@@ -412,7 +412,7 @@ jobs:
           --data-urlencode "deployUrl=${DEPLOY_URL}" \
           --data-urlencode "deployRoot=<%= deployRoot %>" \
           --data-urlencode "artifactUrl=${DOWNLOAD_URL}" \
-          --data-urlencode "artifactSrc=<%= artifactSrc && artifactSrc !== 'repo' ? artifactSrc : 'github' %>" \
+          --data-urlencode "artifactSrc=<%= artifactSrc || 'repo' %>" \
           --data-urlencode "artifactSha256=${ARTIFACT_SHA256}" \
           --data-urlencode "projectVersion=${PROJECT_VERSION}" \
           --data-urlencode "envLong=${{ inputs.environment }}" \


### PR DESCRIPTION
## Summary
- Fix `artifactSrc` value sent to Jenkins in the deploy workflow template.
- Previously `artifactSrc !== 'repo' ? artifactSrc : 'github'` always sent `github` when the catalog was set to `repo`.
- Now passes the catalog value through directly, defaulting to `repo` when absent.

## Why
The deployment job should reflect the `artifactSrc` annotation in `catalog-info.yaml` rather than ignoring it and hardcoding a fallback.
